### PR TITLE
ANFE-40: Updating getReferencedForms() to take a map or array of refe…

### DIFF
--- a/app/scripts/formentry/services/form-schema-compiler.service.js
+++ b/app/scripts/formentry/services/form-schema-compiler.service.js
@@ -301,7 +301,7 @@ jscs:disable disallowMixedSpacesAndTabs, requireDotNotation, requirePaddingNewLi
             console.error('Form compile: Unsupported reference type', referenceData.reference);
         }
 
-        function getReferencedForms(formSchema, formSchemasLookupArray) {
+        function getReferencedForms(formSchema, formSchemaLookup) {
             var referencedForms = formSchema.referencedForms;
 
             if (_.isEmpty(referencedForms)) {
@@ -309,18 +309,23 @@ jscs:disable disallowMixedSpacesAndTabs, requireDotNotation, requirePaddingNewLi
             }
 
             var keyValReferencedForms = {};
-
-            _.each(referencedForms, function (reference) {
-                var referencedFormSchema =
-                    findSchemaByName(formSchemasLookupArray, reference.formName);
-                keyValReferencedForms[reference.alias] = referencedFormSchema;
-            });
+            if(Array.isArray(formSchemaLookup)) {
+              _.each(referencedForms, function (reference) {
+                  var referencedFormSchema =
+                      findSchemaByName(formSchemaLookup, reference.formName);
+                  keyValReferencedForms[reference.alias] = referencedFormSchema;
+              });
+            } else {
+              // Assume it is a key value pair of uuid:schema //i.e this is from
+              // openmrs backend
+              _.each(referencedForms, function (reference) {
+                keyValReferencedForms[reference.alias] = 
+                                        formSchemaLookup[reference.ref.uuid];
+              })
+            }
 
             return keyValReferencedForms;
         }
-
-
-
 
     }
 })();


### PR DESCRIPTION
…renced forms

As an alternative to array of referenced forms, getReferencedForms() can take a
map of form-uuid to schema as a second argument. This is added to facilitate easierreferencing when loading the schemas from OpenMRS via REST as opposed to loading from filesystem which is name based.